### PR TITLE
Store access tokens in cookies

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,6 +1,7 @@
 from datetime import timedelta, datetime, timezone
 from typing import Annotated, Any, override
-from fastapi import Depends, HTTPException, status
+from click.core import F
+from fastapi import Cookie, Depends, HTTPException, status
 import jwt
 from pwdlib import PasswordHash
 from sqlmodel import Session, select
@@ -10,16 +11,8 @@ from app.models import User
 from app.core.settings import settings
 from fastapi.security import OAuth2PasswordBearer
 
-class CustomOAuth2PasswordBearer(OAuth2PasswordBearer):
-    @override
-    def make_not_authenticated_error(self):
-        return HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
 password_hash = PasswordHash.recommended()
-oauth2_scheme = CustomOAuth2PasswordBearer(tokenUrl="/api/token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/token", auto_error=False)
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return password_hash.verify(plain_password, hashed_password)
@@ -40,7 +33,17 @@ def create_access_token(data: dict[str, Any], expires_delta: timedelta | None = 
 def decode_access_token(token: str) -> dict[str, Any]:
     return jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
 
-def get_current_user(session: SessionDep, token: Annotated[str, Depends(oauth2_scheme)]) -> User:
+def get_token_from_cookie_or_header(header_token: Annotated[str | None, Depends(oauth2_scheme)], access_token: Annotated[str | None, Cookie()]) -> str:
+    if access_token:
+        return access_token
+    if header_token:
+        return header_token
+    raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            headers={"WWW-Authenticate": "Bearer"},
+    )
+
+def get_current_user(session: SessionDep, token: Annotated[str, Depends(get_token_from_cookie_or_header)]) -> User:
     try:
         decoded = decode_access_token(token)
     except jwt.InvalidTokenError:

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,6 +1,5 @@
 from datetime import timedelta, datetime, timezone
-from typing import Annotated, Any, override
-from click.core import F
+from typing import Annotated, Any
 from fastapi import Cookie, Depends, HTTPException, status
 import jwt
 from pwdlib import PasswordHash

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
     jwt_secret: str = Field(min_length=32) 
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = Field(default=30, ge=0)
+    cookie_secure: bool = True
 
     postgres_url: PostgresDsn
 

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Form, HTTPException, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Response, status
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestFormStrict
 from sqlalchemy.exc import IntegrityError
@@ -67,3 +67,8 @@ def create_access_token_from_login(session: SessionDep,
         ) 
 
     return response
+
+@router.delete("/token", status_code=status.HTTP_204_NO_CONTENT)
+def delete_access_token_cookie(response: Response):
+    response.delete_cookie("access_token")
+    return None

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -63,7 +63,10 @@ def create_access_token_from_login(session: SessionDep,
         response.set_cookie(
             "access_token",
             access_token,
-            max_age=access_token_expires.seconds
+            max_age=access_token_expires.seconds,
+            samesite="lax",
+            secure=settings.cookie_secure,
+            httponly=True,
         ) 
 
     return response

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -58,13 +58,12 @@ def create_access_token_from_login(session: SessionDep,
 
     access_token_expires = timedelta(minutes=settings.access_token_expire_minutes)
     access_token = create_access_token({"sub": str(user.id)}, expires_delta=access_token_expires)
-
     response = JSONResponse(content=AccessTokenPublic(access_token=access_token, token_type="Bearer").model_dump())
     if client_type == "web":
         response.set_cookie(
             "access_token",
             access_token,
-            max_age=access_token_expires
+            max_age=access_token_expires.seconds
         ) 
 
     return response

--- a/app/routers/api.py
+++ b/app/routers/api.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, Form, HTTPException, status
+from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestFormStrict
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
@@ -48,11 +49,22 @@ def create_user(body: UserCreate, session: SessionDep):
     return user_db
 
 @router.post("/token", response_model=AccessTokenPublic)
-def create_access_token_from_login(form_body: Annotated[OAuth2PasswordRequestFormStrict, Depends()], session: SessionDep):
+def create_access_token_from_login(session: SessionDep,
+                                   form_body: Annotated[OAuth2PasswordRequestFormStrict, Depends()],
+                                   client_type: Annotated[str | None, Form()] = None):
     user = authenticate_user(session, form_body.username, form_body.password)
     if not user:
         raise OAuth2PasswordException("invalid_grant", description="Incorrect username or password")
 
     access_token_expires = timedelta(minutes=settings.access_token_expire_minutes)
     access_token = create_access_token({"sub": str(user.id)}, expires_delta=access_token_expires)
-    return AccessTokenPublic(access_token=access_token, token_type="Bearer")
+
+    response = JSONResponse(content=AccessTokenPublic(access_token=access_token, token_type="Bearer").model_dump())
+    if client_type == "web":
+        response.set_cookie(
+            "access_token",
+            access_token,
+            max_age=access_token_expires
+        ) 
+
+    return response

--- a/tests/core/test_security.py
+++ b/tests/core/test_security.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
 import time
+from fastapi import HTTPException
 import jwt
-from app.core.security import OAuth2PasswordException, authenticate_user, create_access_token, decode_access_token, get_current_enabled_user, get_current_user, get_hashed_password, verify_password
+from app.core.security import OAuth2PasswordException, authenticate_user, create_access_token, decode_access_token, get_current_enabled_user, get_current_user, get_hashed_password, get_token_from_cookie_or_header, verify_password
 import pytest
 from unittest.mock import Mock, patch
 from app.models import User
@@ -88,6 +89,17 @@ def test_authenticate_user_incorrect_password():
 
     result = authenticate_user(session_mock, TEST_EMAIL, TEST_PASSWORD + "123")
     assert result is None
+
+def test_get_token_from_cookie_or_header():
+    assert get_token_from_cookie_or_header("header_token", None) == "header_token"
+    assert get_token_from_cookie_or_header(None, "cookie_token") == "cookie_token"
+
+def test_get_token_from_cookie_or_header_none():
+    with pytest.raises(HTTPException) as exc_info:
+        get_token_from_cookie_or_header(None, None)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.headers["WWW-Authenticate"] == "Bearer"
 
 def test_get_current_user():
     test_user = User(email=TEST_EMAIL, password_hash=TEST_PASSWORD, disabled=True)

--- a/tests/routers/test_api.py
+++ b/tests/routers/test_api.py
@@ -97,6 +97,7 @@ def test_create_access_token_from_login(session: Session, client: TestClient):
     data = response.json()
 
     assert response.status_code == 200
+    assert "set-cookie" not in response.headers
     assert data["token_type"] == "Bearer"
     assert data["access_token"] is not None
     assert isinstance(data["access_token"], str)
@@ -107,6 +108,24 @@ def test_create_access_token_from_login(session: Session, client: TestClient):
     assert decoded["exp"] is not None
     assert isinstance(decoded["exp"], int)
     assert decoded["exp"] > 0
+
+def test_create_access_token_from_login_with_cookie(session: Session, client: TestClient):
+    test_user = User(email=TEST_EMAIL, password_hash=get_hashed_password(TEST_PASSWORD))
+    session.add(test_user)
+    session.commit()
+    session.refresh(test_user)
+
+    response = client.post(
+            "/api/token",
+            data={"grant_type": "password", "username": TEST_EMAIL, "password": TEST_PASSWORD, "client_type": "web"},
+    )
+    data = response.json()
+    
+    assert response.status_code == 200
+    assert data["token_type"] == "Bearer"
+    assert data["access_token"] is not None
+    assert response.cookies.get("access_token") is not None
+    assert len(response.cookies.get("access_token")) > 0 
 
 def test_create_access_token_from_login_invalid_input(client: TestClient):
     response = client.post(

--- a/tests/routers/test_api.py
+++ b/tests/routers/test_api.py
@@ -151,7 +151,8 @@ def test_create_access_token_from_login_incorrect_credentials(client: TestClient
     assert isinstance(data["error_description"], str)
 
 def test_delete_access_token_cookie(client: TestClient):
-    response = client.delete("/api/token", cookies={"access_token": "test_token"})
+    client.cookies.set("access_token", "test_token")
+    response = client.delete("/api/token")
 
     assert response.status_code == 204
     assert response.cookies.get("access_token") is None

--- a/tests/routers/test_api.py
+++ b/tests/routers/test_api.py
@@ -149,3 +149,10 @@ def test_create_access_token_from_login_incorrect_credentials(client: TestClient
     assert data["error"] == "invalid_grant" 
     assert data["error_description"] is not None
     assert isinstance(data["error_description"], str)
+
+def test_delete_access_token_cookie(client: TestClient):
+    response = client.delete("/api/token", cookies={"access_token": "test_token"})
+
+    assert response.status_code == 204
+    assert response.cookies.get("access_token") is None
+    assert response.content == b""


### PR DESCRIPTION
# Description

This issue changes our backend to accept and set access tokens in cookies as well as adding an option to delete the cookie. Closes #21 

## Changes

- Modified `POST /token` route to optionally set access token as a cookie 
  - `client_type` in form body needs to be specified as `web`
- Added new route `DELETE /token` which deletes access token cookie
- Added new settings option `cookie_secure`
  - It controles if cookie should be set with `Secure` parameter
- Added new function `get_token_from_cookie_or_header`
  - It's the new default way of getting token from user request

## Notes

- Some basic security measures were added in form of cookie params
  - Security is still needs to be reviewed
- Cookie support was added in a way that still supports standard authentication via header 