### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ WORKDIR /usr/local/src
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY .env .
-
 COPY app app
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.14.4
+
+WORKDIR /usr/local/src
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY .env .
+
+COPY app app
+EXPOSE 8000
+
+RUN useradd app
+USER app
+
+CMD ["fastapi", "run", "app/main.py", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/local/src
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+COPY alembic.ini alembic.ini
 COPY app app
 EXPOSE 8000
 

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -1,5 +1,5 @@
 from fastapi.templating import Jinja2Templates
-from pydantic import Field, PostgresDsn, field_validator
+from pydantic import Field, PostgresDsn, computed_field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
@@ -8,16 +8,22 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = Field(default=30, ge=0)
     cookie_secure: bool = True
 
-    postgres_url: PostgresDsn
+    postgres_host: str = "localhost"
+    postgres_port: int = 5432
+    postgres_user: str = "postgres"
+    postgres_password: str = "postgres"
+    postgres_db: str = "postgres"
 
-    @field_validator("postgres_url", mode='after')
-    @classmethod
-    def is_db(cls, postgres_url: PostgresDsn):
-        path = postgres_url.path or ""
-        db_name = path.lstrip("/")
-        if not db_name:
-            raise ValueError("Postgres URL must include a database name")
-        return postgres_url
+    @property
+    def postgres_url(self) -> PostgresDsn:
+        return PostgresDsn.build(
+            scheme="postgresql+psycopg2",
+            host=self.postgres_host,
+            port=self.postgres_port,
+            username=self.postgres_user,
+            password=self.postgres_password,
+            path=self.postgres_db
+        )
 
     model_config = SettingsConfigDict(env_file=".env") # pyright: ignore[reportUnannotatedClassAttribute]
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,22 @@ services:
     environment:
       - POSTGRES_HOST=db
     depends_on:
-      - db
+      migrate:
+        condition: service_completed_successfully
+  migrate:
+    build: .
+    command: alembic upgrade head
+    env_file: .env
+    environment:
+      - POSTGRES_HOST=db
+    depends_on:
+      db:
+        condition: service_healthy
+        restart: true
   db:
     image: postgres:18.3
     env_file: .env
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 1s
+      timeout: 10s

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file: ".env"
+    

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 services:
   app:
     build: .
+    image: py-link-shortener-app
     ports:
       - "8000:8000"
     env_file: .env
@@ -10,7 +11,8 @@ services:
       migrate:
         condition: service_completed_successfully
   migrate:
-    build: .
+    image: py-link-shortener-app
+    pull_policy: never
     command: alembic upgrade head
     env_file: .env
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,5 +3,11 @@ services:
     build: .
     ports:
       - "8000:8000"
-    env_file: ".env"
-    
+    env_file: .env
+    environment:
+      - POSTGRES_HOST=db
+    depends_on:
+      - db
+  db:
+    image: postgres:18.3
+    env_file: .env


### PR DESCRIPTION
# Description

This PR adds Docker support by adding an easy way of starting application and neccesary services in isolated, predictable environment. Closes #29 

# Notes

- For database migration step I specified temporary docker service/container
  - It uses already build app image as to reducing unnecessary amount of images
  - app can only run after it's completed via `condition` check
- `condition` check was also added to database to detect if it's ready to accept connections  

## Changes

- Added `Dockerfile` which specifies how to build container for python backend
- Added `compose.yml` which specifies how and what containers should be run
- Changed `settings.py` db fields to be compatible with postgres image environment variables

## Testing

1. Run application by writing command line `docker compose up`
2. The application should be successfully running and be available at `http://localhost:8000`