### PR TITLE
Add rate limiting

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,23 +1,32 @@
+from curses import window
 import time
 
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
 
-RATE_LIMIT = 60
-WINDOW_DURATION = 60
+def get_rate_limit_parameters(path: str, method: str) -> tuple[int, int]:
+    if path == "/api/short" and method == "POST":
+        return 10, 60
+    elif path == "/api/token" and method == "POST":
+        return 5, 60 
+    elif path == "/api/users" and method == "POST":
+        return 5, 60
+    return 60, 60
 
 clients: dict[str, list] = {}
 
 async def rate_limit_middleware(request: Request, call_next):
         ip = request.client.host
         now = time.time()
+        print(f"Received request from {ip} to {request.url.path} with method {request.method}")
+        rate_limit, window_duration = get_rate_limit_parameters(request.url.path, request.method)
 
         if ip not in clients:
             clients[ip] = []
 
-        clients[ip] = [t for t in clients[ip] if now - t <= WINDOW_DURATION]
+        clients[ip] = [t for t in clients[ip] if now - t <= window_duration]
 
-        if len(clients[ip]) >= RATE_LIMIT:
+        if len(clients[ip]) >= rate_limit:
             return JSONResponse(status_code=status.HTTP_429_TOO_MANY_REQUESTS, content={"detail": "Too many requests"})
 
         clients[ip].append(now)

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,0 +1,25 @@
+import time
+
+from fastapi import Request, status
+from fastapi.responses import JSONResponse
+
+RATE_LIMIT = 60
+WINDOW_DURATION = 60
+
+clients: dict[str, list] = {}
+
+async def rate_limit_middleware(request: Request, call_next):
+        ip = request.client.host
+        now = time.time()
+
+        if ip not in clients:
+            clients[ip] = []
+
+        clients[ip] = [t for t in clients[ip] if now - t <= WINDOW_DURATION]
+
+        if len(clients[ip]) >= RATE_LIMIT:
+            return JSONResponse(status_code=status.HTTP_429_TOO_MANY_REQUESTS, content={"detail": "Too many requests"})
+
+        clients[ip].append(now)
+        return await call_next(request)
+

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -18,7 +18,6 @@ clients: dict[str, list] = {}
 async def rate_limit_middleware(request: Request, call_next):
         ip = request.client.host
         now = time.time()
-        print(f"Received request from {ip} to {request.url.path} with method {request.method}")
         rate_limit, window_duration = get_rate_limit_parameters(request.url.path, request.method)
 
         if ip not in clients:

--- a/app/main.py
+++ b/app/main.py
@@ -3,10 +3,13 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.staticfiles import StaticFiles
 
 from app.core.exceptions import OAuth2PasswordException, custom_request_validation_error_handler, http_not_found_exception_handler, oauth2_password_exception_handler
+from app.core.middleware import rate_limit_middleware
 from app.routers import api, web
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+app.middleware("http")(rate_limit_middleware)
 
 app.add_exception_handler(status.HTTP_404_NOT_FOUND, http_not_found_exception_handler)
 app.add_exception_handler(OAuth2PasswordException, oauth2_password_exception_handler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from sqlmodel import SQLModel, Session, create_engine
 import pytest
 from app.core.database import get_session
 from app.core.security import get_hashed_password
+from app.core.middleware import clients
 from app.main import app
 from app.models import User
 
@@ -59,5 +60,7 @@ def auth_fixture(client: TestClient, user: User):
     data = response.json()
     return {"user": user, "token": data["access_token"]}
 
-    
+@pytest.fixture(autouse=True)
+def clear_rate_limit_clients():
+    clients.clear()
 

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from httpx import patch
+
+
+def test_rate_limit_middleware(client: TestClient):
+    for _ in range(100):
+        response = client.get("/")
+
+    assert response.status_code == 429
+    assert response.json() == {"detail": "Too many requests"}

--- a/tests/core/test_middleware.py
+++ b/tests/core/test_middleware.py
@@ -8,3 +8,9 @@ def test_rate_limit_middleware(client: TestClient):
 
     assert response.status_code == 429
     assert response.json() == {"detail": "Too many requests"}
+
+def test_rate_limit_middleware_different_paths(client: TestClient):
+    for _ in range(10):
+        response = client.post("/api/token", data={"grant_type": "password", "username": "test", "password": "test"})
+    assert response.status_code == 429
+    assert response.json() == {"detail": "Too many requests"}


### PR DESCRIPTION
# Description

This PR adds basic rate limiting for all routes and more stricter rate limiting for some special routes. Closes #31 

## Changes

- Added `rate_limiter_middleware` for limiting request based on user IP
- Added  `get_rate_limit_parameters` for getting rate limiting rules based on route

## Testing

- Added Integration tests for rate limiting middleware
- Added fixture for clearing rate limiting data after each test

## Notes

- Currently memory-based implementation was used which is limited but easy to implement
- Stricter rate limiting was applied for auth endpoint of getting token to prevent brute-forcing